### PR TITLE
 README.md

### DIFF
--- a/README.
+++ b/README.
@@ -1,0 +1,13 @@
+com.google.android.apps.messaging(20484):
+
+type=1400 audit(0.0:107812): avc: denied { read } for comm=424720546872656164202337
+
+name="u:object_r:vendor_tct_prop:s0"
+
+dev="tmpfs" ino=14550 scontext=u:r:untrusted_app:s0:c191,c256,c512,c768
+
+tcontext=u:object_r:vendor_tct_prop:s0 tclass=file permissive=0
+
+app=com.google.android.apps.messaging 06-01 15:13:27.713 D/
+
+NetworkController.MobileSignal Controller(1)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,0 @@
-head><title></title> 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" /> 
-<meta name="generator" content="TeX4ht (https://tug.org/tex4ht/)" /> 
-<meta name="originator" content="TeX4ht (https://tug.org/tex4ht/)" /> 
-<!-- xhtml,charset=utf-8,html --> 
-<meta name="src" content="analisi.tex" /> 
-<link rel="stylesheet" type="text/css" href="analisi.css" /> 
-</head><body 
->


### PR DESCRIPTION
com.google.android.apps.messaging(20484):

type=1400 audit(0.0:107812): avc: denied { read } for comm=424720546872656164202337

name="u:object_r:vendor_tct_prop:s0"

dev="tmpfs" ino=14550 scontext=u:r:untrusted_app:s0:c191,c256,c512,c768

tcontext=u:object_r:vendor_tct_prop:s0 tclass=file permissive=0

app=com.google.android.apps.messaging 06-01 15:13:27.713 D/

NetworkController.MobileSignal Controller(1)